### PR TITLE
Add workflow: Update latest downloads on download.eclipse.org

### DIFF
--- a/.github/workflows/update-latest-downloads.yml
+++ b/.github/workflows/update-latest-downloads.yml
@@ -1,0 +1,81 @@
+name: Update latest downloads on download.eclipse.org
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to mark as latest (e.g., 1.7.2)'
+        required: true
+        type: string
+
+jobs:
+  update-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v4.1.1
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "${{ secrets.SSH_PASSPHRASE }}" | ssh-add ~/.ssh/id_ed25519 2>/dev/null || true
+
+      - name: Update latest symlinks on download.eclipse.org
+        run: |
+          ssh -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              genie.zenoh@projects-storage.eclipse.org \
+              "
+              set -e
+              VERSION='${{ inputs.version }}'
+              BASE_PATH='/home/data/httpd/download.eclipse.org/zenoh'
+              UPDATED_COUNT=0
+              
+              echo '🔍 Scanning for zenoh packages with version \$VERSION...'
+              for i in \$BASE_PATH/z*/\$VERSION; do
+                if [ -d \"\$i\" ]; then
+                  DEST=\$(realpath \$i/../latest)
+                  echo \"📦 Updating: \$i → \$DEST\"
+                  rm -rf \"\$DEST\"
+                  mkdir -p \"\$DEST\"
+                  cp -r \"\$i\"/* \"\$DEST/\"
+                  UPDATED_COUNT=\$((UPDATED_COUNT + 1))
+                  echo \"✅ Updated: \$DEST\"
+                fi
+              done
+              
+              if [ \$UPDATED_COUNT -eq 0 ]; then
+                echo '⚠️  No packages found for version '\$VERSION
+                exit 1
+              fi
+              
+              echo \"\"
+              echo \"🎉 Successfully updated \$UPDATED_COUNT package(s) to latest\"
+              "
+
+      - name: Verify updates
+        run: |
+          ssh -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              genie.zenoh@projects-storage.eclipse.org \
+              "
+              set -e
+              BASE_PATH='/home/data/httpd/download.eclipse.org/zenoh'
+              
+              echo '🔍 Verifying latest directories...'
+              for latest_dir in \$BASE_PATH/z*/latest; do
+                if [ -d \"\$latest_dir\" ]; then
+                  FILE_COUNT=\$(find \"\$latest_dir\" -type f | wc -l)
+                  echo \"  ✅ \$latest_dir (\$FILE_COUNT files)\"
+                fi
+              done
+              "
+
+      - name: Report completion
+        if: always()
+        run: |
+          echo "Update Latest Downloads Workflow Completed"
+          echo "Version: ${{ inputs.version }}"
+          echo "Timestamp: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"

--- a/.github/workflows/update-latest-downloads.yml
+++ b/.github/workflows/update-latest-downloads.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to mark as latest (e.g., 1.7.2)'
         required: true
         type: string
+      dry-run:
+        description: 'Test mode - verify connections and show what would be updated without modifying'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   update-latest:
@@ -24,6 +29,7 @@ jobs:
 
       - name: Update latest symlinks on download.eclipse.org
         run: |
+          DRY_RUN="${{ inputs.dry-run }}"
           ssh -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               genie.zenoh@projects-storage.eclipse.org \
@@ -33,16 +39,28 @@ jobs:
               BASE_PATH='/home/data/httpd/download.eclipse.org/zenoh'
               UPDATED_COUNT=0
               
+              if [ \"\$DRY_RUN\" = \"true\" ]; then
+                echo '🧪 DRY-RUN MODE - Credentials verified, no changes will be made'
+                echo ''
+              fi
+              
               echo '🔍 Scanning for zenoh packages with version \$VERSION...'
               for i in \$BASE_PATH/z*/\$VERSION; do
                 if [ -d \"\$i\" ]; then
                   DEST=\$(realpath \$i/../latest)
-                  echo \"📦 Updating: \$i → \$DEST\"
-                  rm -rf \"\$DEST\"
-                  mkdir -p \"\$DEST\"
-                  cp -r \"\$i\"/* \"\$DEST/\"
+                  
+                  if [ \"\$DRY_RUN\" = \"true\" ]; then
+                    FILE_COUNT=\$(find \"\$i\" -type f | wc -l)
+                    echo \"📦 [DRY-RUN] Would update: \$i (\$FILE_COUNT files) → \$DEST\"
+                  else
+                    echo \"📦 Updating: \$i → \$DEST\"
+                    rm -rf \"\$DEST\"
+                    mkdir -p \"\$DEST\"
+                    cp -r \"\$i\"/* \"\$DEST/\"
+                    echo \"✅ Updated: \$DEST\"
+                  fi
+                  
                   UPDATED_COUNT=\$((UPDATED_COUNT + 1))
-                  echo \"✅ Updated: \$DEST\"
                 fi
               done
               
@@ -52,7 +70,11 @@ jobs:
               fi
               
               echo \"\"
-              echo \"🎉 Successfully updated \$UPDATED_COUNT package(s) to latest\"
+              if [ \"\$DRY_RUN\" = \"true\" ]; then
+                echo \"🎉 DRY-RUN successful: would update \$UPDATED_COUNT package(s)\"
+              else
+                echo \"🎉 Successfully updated \$UPDATED_COUNT package(s) to latest\"
+              fi
               "
 
       - name: Verify updates

--- a/.github/workflows/update-latest-downloads.yml
+++ b/.github/workflows/update-latest-downloads.yml
@@ -50,14 +50,12 @@ jobs:
                   DEST=\$(realpath \$i/../latest)
                   
                   if [ \"\$DRY_RUN\" = \"true\" ]; then
-                    FILE_COUNT=\$(find \"\$i\" -type f | wc -l)
-                    echo \"📦 [DRY-RUN] Would update: \$i (\$FILE_COUNT files) → \$DEST\"
+                    echo \"🔗 [DRY-RUN] Would create symlink: \$DEST → \$i\"
                   else
-                    echo \"📦 Updating: \$i → \$DEST\"
+                    echo \"🔗 Creating symlink: \$DEST → \$i\"
                     rm -rf \"\$DEST\"
-                    mkdir -p \"\$DEST\"
-                    cp -r \"\$i\"/* \"\$DEST/\"
-                    echo \"✅ Updated: \$DEST\"
+                    ln -sfr \"\$i\" \"\$DEST\"
+                    echo \"✅ Symlink created: \$DEST\"
                   fi
                   
                   UPDATED_COUNT=\$((UPDATED_COUNT + 1))
@@ -71,9 +69,9 @@ jobs:
               
               echo \"\"
               if [ \"\$DRY_RUN\" = \"true\" ]; then
-                echo \"🎉 DRY-RUN successful: would update \$UPDATED_COUNT package(s)\"
+                echo \"🎉 DRY-RUN successful: would create \$UPDATED_COUNT symlink(s)\"
               else
-                echo \"🎉 Successfully updated \$UPDATED_COUNT package(s) to latest\"
+                echo \"🎉 Successfully created \$UPDATED_COUNT symlink(s) to latest\"
               fi
               "
 
@@ -86,11 +84,11 @@ jobs:
               set -e
               BASE_PATH='/home/data/httpd/download.eclipse.org/zenoh'
               
-              echo '🔍 Verifying latest directories...'
-              for latest_dir in \$BASE_PATH/z*/latest; do
-                if [ -d \"\$latest_dir\" ]; then
-                  FILE_COUNT=\$(find \"\$latest_dir\" -type f | wc -l)
-                  echo \"  ✅ \$latest_dir (\$FILE_COUNT files)\"
+              echo '🔍 Verifying latest symlinks...'
+              for latest_link in \$BASE_PATH/z*/latest; do
+                if [ -L \"\$latest_link\" ]; then
+                  TARGET=\$(readlink \"\$latest_link\")
+                  echo \"  ✅ \$latest_link → \$TARGET\"
                 fi
               done
               "

--- a/README.md
+++ b/README.md
@@ -3,3 +3,47 @@
 This repository contains a set of GitHub actions and (reusable) workflows used
 to implement cross-repository workflows and reuse workflows across the
 eclipse-zenoh organization.
+
+## Workflows
+
+### update-latest-downloads.yml
+
+**Purpose**: Update the "latest" symlink on download.eclipse.org to point to a specific release version.
+
+**Trigger**: Manual (`workflow_dispatch`)
+
+**Inputs**:
+- `version` (required): The version to mark as latest (e.g., `1.7.2`)
+
+**Required Secrets**:
+- `SSH_PRIVATE_KEY`: SSH private key (ED25519) for `genie.zenoh` authentication
+- `SSH_PASSPHRASE`: Passphrase for the SSH key (if key is encrypted)
+
+**Setup**:
+Request SCP credentials from Eclipse CBI by opening a [HelpDesk issue](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/new) with the following:
+- Project: Zenoh
+- Request: SSH credentials for `projects-storage.eclipse.org`
+- Purpose: Automated downloads.eclipse.org management
+
+Once credentials are provided, add them as GitHub Secrets:
+1. Navigate to Settings → Secrets and variables → Actions
+2. Create the four secrets listed above
+3. Alternatively, add via [Otterdog configuration](https://github.com/eclipse-cbi/.eclipsefdn)
+
+**Behavior**:
+1. Connects to `projects-storage.eclipse.org` via SSH
+2. For each package directory matching `/home/data/httpd/download.eclipse.org/zenoh/z*/{version}/`:
+   - Copies all files to the corresponding `latest/` directory
+   - Removes old `latest/` directory before copying
+   - Creates `latest/` if it doesn't exist
+3. Reports the number of packages updated
+4. Verifies all `latest/` directories contain files
+
+**Example**:
+To update latest downloads for version 1.7.2:
+1. Navigate to Actions → Update latest downloads on download.eclipse.org
+2. Click "Run workflow"
+3. Enter `1.7.2` in the version field
+4. Click "Run workflow"
+
+The workflow will update all package "latest" directories to mirror the 1.7.2 release artifacts.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ Once credentials are provided, add them as GitHub Secrets:
 **Behavior**:
 1. Connects to `projects-storage.eclipse.org` via SSH
 2. For each package directory matching `/home/data/httpd/download.eclipse.org/zenoh/z*/{version}/`:
-   - **Dry-run mode**: Lists files that would be copied without making changes
-   - **Live mode**: Copies all files to the corresponding `latest/` directory, removing old `latest/` first
-3. Reports the number of packages updated/would be updated
-4. In dry-run: Verifies SSH connection and credentials work
-5. In live: Verifies all `latest/` directories contain files
+   - **Dry-run mode**: Lists symlinks that would be created without making changes
+   - **Live mode**: Creates symlinks from `latest/` to the version directory (removes old symlinks first)
+3. Symlinks are force-created with `ln -sfr` (space-efficient, points to actual version directory)
+4. Reports the number of symlinks created/would be created
+5. In dry-run: Verifies SSH connection and credentials work
+6. In live: Verifies all `latest/` symlinks point to correct version directories
 
 **Usage**:
 First-time setup: Use `dry-run: true` to verify credentials:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ eclipse-zenoh organization.
 
 **Inputs**:
 - `version` (required): The version to mark as latest (e.g., `1.7.2`)
+- `dry-run` (optional): Test mode - verify credentials and show what would be updated without modifying (default: `false`)
 
 **Required Secrets**:
 - `SSH_PRIVATE_KEY`: SSH private key (ED25519) for `genie.zenoh` authentication
@@ -33,17 +34,19 @@ Once credentials are provided, add them as GitHub Secrets:
 **Behavior**:
 1. Connects to `projects-storage.eclipse.org` via SSH
 2. For each package directory matching `/home/data/httpd/download.eclipse.org/zenoh/z*/{version}/`:
-   - Copies all files to the corresponding `latest/` directory
-   - Removes old `latest/` directory before copying
-   - Creates `latest/` if it doesn't exist
-3. Reports the number of packages updated
-4. Verifies all `latest/` directories contain files
+   - **Dry-run mode**: Lists files that would be copied without making changes
+   - **Live mode**: Copies all files to the corresponding `latest/` directory, removing old `latest/` first
+3. Reports the number of packages updated/would be updated
+4. In dry-run: Verifies SSH connection and credentials work
+5. In live: Verifies all `latest/` directories contain files
 
-**Example**:
-To update latest downloads for version 1.7.2:
+**Usage**:
+First-time setup: Use `dry-run: true` to verify credentials:
 1. Navigate to Actions → Update latest downloads on download.eclipse.org
 2. Click "Run workflow"
-3. Enter `1.7.2` in the version field
-4. Click "Run workflow"
+3. Enter the version (e.g., `1.7.2`)
+4. Check `dry-run` checkbox
+5. Click "Run workflow"
+6. Workflow will connect and show what would be updated without making changes
 
-The workflow will update all package "latest" directories to mirror the 1.7.2 release artifacts.
+Production run: Once dry-run succeeds, run again with `dry-run: false` to actually update files.


### PR DESCRIPTION
## Summary
Replaces Jenkins 'Downloads - update latest' job with GitHub Actions workflow.

## Changes
- New workflow: `.github/workflows/update-latest-downloads.yml`
- Accepts `version` parameter via workflow_dispatch
- Creates symlinks from `latest/` → version directories on download.eclipse.org
- Includes dry-run option to verify credentials without modifying files
- Updated README with setup instructions and usage examples

## Implementation Details
- Connects to `projects-storage.eclipse.org` via SSH as `genie.zenoh`
- Scans for all `zenoh-z*/version/` directories
- Creates force symlinks: `ln -sfr` (space-efficient approach)
- Dry-run mode lists what would be created without making changes
- Verification step confirms all symlinks are correctly established

## Secrets Required
- `SSH_PRIVATE_KEY`: ED25519 key for genie.zenoh authentication
- `SSH_PASSPHRASE`: Key passphrase (if encrypted)

## Usage
1. Go to Actions → Update latest downloads on download.eclipse.org
2. Click 'Run workflow'
3. Enter version (e.g., 1.7.2)
4. Optionally check 'dry-run' to test credentials first
5. Click 'Run workflow'

## Testing
- Dry-run mode verifies SSH connection works
- Prints symlink targets for verification
- Handles missing version directories gracefully